### PR TITLE
function typo

### DIFF
--- a/contracts/IExerciseSolution.cairo
+++ b/contracts/IExerciseSolution.cairo
@@ -10,7 +10,7 @@ namespace IExerciseSolution:
     func tokens_in_custody(account : felt) -> (amount : Uint256):
     end
 
-    func get_tokens_from_contract() -> (amount : Uint256):
+    func get_tokens() -> (amount : Uint256):
     end
 
     func withdraw_all_tokens() -> (amount : Uint256):


### PR DESCRIPTION
In the exercise the function is called get_tokens while in the interface its called get_tokens_from_contract.
The evaluator use get_tokens.